### PR TITLE
Debian build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,8 @@ Section: admin
 Priority: optional
 Maintainer: Jehan-Guillaume (ioguix) de Rorthais <jgdr@dalibo.com>
 Build-Depends: debhelper (>= 9),
-               libmodule-build-perl
+               libmodule-build-perl,
+               resource-agents,
 Standards-Version: 3.9.5
 Homepage: http://dalibo.github.io/PAF/
 

--- a/debian/files
+++ b/debian/files
@@ -1,1 +1,0 @@
-resource-agents-paf_2.0.0-1_all.deb admin optional


### PR DESCRIPTION
* Add resource-agents to Build-Depends
  Fixes:
    Couldn't find OCF shell functions in «OCF_ROOT/lib/heartbeat»!
    Try to build using the --with_ocf_root argument.
* Remove debian/files from git
  It's a temporary file built by dpkg-buildpackage and removed on clean.
  It shouldn't be tracked.