### PR TITLE
Set master scores also on the unavailable members

### DIFF
--- a/script/pgsqlms
+++ b/script/pgsqlms
@@ -523,13 +523,13 @@ sub _query {
 # Return list of all nodes in the cluster (including not available ones).
 # The output format is a comma separated list of nodenames.
 sub _get_all_cluster_nodes {
-	my $nodes_raw = qx{ $CRM_NODE --list };
-	my $allnodes = '';
-	for (split /^/, $nodes_raw) {
-		$_ =~ m/\d\s([a-zA-Z0-9_]+).*$/;
-		$allnodes = "$allnodes $1" if defined $1;
-	}
-	return $allnodes;
+    my $nodes_raw = qx{ $CRM_NODE --list };
+    my $allnodes = '';
+    for (split /^/, $nodes_raw) {
+        $_ =~ m/\d\s([a-zA-Z0-9_]+).*$/;
+        $allnodes = "$allnodes $1" if defined $1;
+    }
+    return $allnodes;
 }
 
 # Check the write_location of all secondaries, and adapt their master score so
@@ -554,9 +554,9 @@ sub _check_locations {
     my @rs;
     my $rc;
 
-	## Get a list of all nodes so we can find out which ones are not connected
+    ## Get a list of all nodes so we can find out which ones are not connected
     ## to the master (and ajust scores accordingly).
-	my $partition_nodes = _get_all_cluster_nodes();
+    my $partition_nodes = _get_all_cluster_nodes();
 
     # We check locations of connected standbies by querying the
     # "pg_stat_replication" view.

--- a/script/pgsqlms
+++ b/script/pgsqlms
@@ -520,6 +520,17 @@ sub _query {
     return $rc;
 }
 
+# Return list of all nodes in the cluster (including not available ones).
+# The output format is a comma separated list of nodenames.
+sub _get_all_cluster_nodes {
+	my $nodes_raw = qx{ $CRM_NODE --list };
+	my $allnodes = '';
+	for (split /^/, $nodes_raw) {
+		$_ =~ m/\d\s([a-zA-Z0-9_]+).*$/;
+		$allnodes = "$allnodes $1" if defined $1;
+	}
+	return $allnodes;
+}
 
 # Check the write_location of all secondaries, and adapt their master score so
 # that the instance closest to the master will be the selected candidate should
@@ -543,9 +554,9 @@ sub _check_locations {
     my @rs;
     my $rc;
 
-    # Call crm_node to exclude nodes that are not part of the cluster at this
-    # point.
-    my $partition_nodes = qx{ $CRM_NODE --partition };
+	## Get a list of all nodes so we can find out which ones are not connected
+    ## to the master (and ajust scores accordingly).
+	my $partition_nodes = _get_all_cluster_nodes();
 
     # We check locations of connected standbies by querying the
     # "pg_stat_replication" view.


### PR DESCRIPTION
Hi.
When the master crashes and is kicked out of the cluster, his master score remains set on 1001. This can be dangerous if you shut down whole cluster and then bring online the old master first. It is most dangerous with the 2-node cluster.
My proposal is to set master scores to -1000 also to unavailable cluster members, because they obviously cannot become masters until resynced.

Simply said, I've replaced 
```crm_node --partition```
by 
```crm_node --nodes```
here https://github.com/dalibo/PAF/blob/master/script/pgsqlms#L548

This was also mentioned in #26.

Jan