### PR TITLE
Add check for notify=true in master meta parameters

### DIFF
--- a/script/pgsqlms
+++ b/script/pgsqlms
@@ -1031,10 +1031,22 @@ sub ocf_methods {
 
 sub pgsql_validate_all {
     my $fh;
+    my $ans = '';
     my $PGVERSION;
     my $PGVERNUM;
     my @content;
     my %cdata;
+
+    # check notify=true
+    $ans = qx{ $CRM_RESOURCE --resource "$OCF_RESOURCE_INSTANCE" \\
+                 --meta --get-parameter notify 2>/dev/null };
+    chomp $ans;
+    unless ( $ans eq 'true' ) {
+        ocf_exit_reason(
+            'You must set meta parameter notify=true for your master resource',
+            $pgdata );
+        exit $OCF_ERR_INSTALLED;
+    }
 
     # check pgdata
     if ( ! -d $pgdata ) {


### PR DESCRIPTION
PAF relies heavily on notify action. This patch make sure the master
resource is created with notify=true as paramter. PAF will refuse to
start the resource if this parameter is not set.