### PR TITLE
Changing info messages and documentation for the maxlag parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ can set:
   * `system_user`: the system owner of your instance's process (default:
     `postgres`)
   * `maxlag`: maximum lag allowed on a standby before we set a negative master
-     score on it. (default: 0, which disables this feature)
+     score on it. The calculation is based on the difference between the current
+     xlog location on the master and the write location on the standby.
+     (default: 0, which disables this feature)
 
 For a demonstration about how to setup a cluster, see
 [http://dalibo.github.com/PAF/documentation.html](http://dalibo.github.com/PAF/documentation.html).

--- a/script/pgsqlms
+++ b/script/pgsqlms
@@ -979,7 +979,9 @@ sub ocf_meta_data {
 
            <parameter name="maxlag" unique="0" required="0">
               <longdesc lang="en">
-	        Maximum lag allowed on a standby before we set a negative master score on it. 
+                Maximum lag allowed on a standby before we set a negative master score on it. The calculation
+                is based on the difference between the current xlog location on the master and the write
+                location on the standby.
                 This parameter must be a valid positive number as described in PostgreSQL documentation.
                 See: https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS-NUMERIC
               </longdesc>

--- a/script/pgsqlms
+++ b/script/pgsqlms
@@ -605,7 +605,7 @@ sub _check_locations {
     # The result set itself is order by priority DESC to process best known
     # candidate first.
     $query = qq{
-      SELECT application_name, priority, location, state
+      SELECT application_name, priority, location, state, current_lag
       FROM (
         SELECT application_name,
           (1000 - (
@@ -615,13 +615,14 @@ sub _check_locations {
             ) - 1
            ) * 10
 	  ) * CASE WHEN ($maxlag > 0
-	                 AND pg_xlog_location_diff(pg_current_xlog_location(), write_location) > $maxlag)
+	                 AND current_lag > $maxlag)
                         THEN -1
                    ELSE 1
               END AS priority,
-          write_location AS location, state
+          write_location AS location, state, current_lag
         FROM (
-          SELECT application_name, write_location, state
+          SELECT application_name, write_location, state,
+                 pg_xlog_location_diff(pg_current_xlog_location(), write_location) AS current_lag
           FROM pg_stat_replication
         ) AS s2
       ) AS s1
@@ -670,12 +671,18 @@ sub _check_locations {
         }
         else {
             ocf_log( 'debug',
-                '_check_locations: checking "%s" promotion ability (current_score: %s, priority: %s, location: %s)',
-                $row->[0], $node_score, $row->[1], $row->[2] );
+                '_check_locations: checking "%s" promotion ability (current_score: %s, priority: %s, location: %s, lag: %s)',
+                $row->[0], $node_score, $row->[1], $row->[2], $row->[4] );
 
             if ( $node_score ne $row->[1] ) {
-                ocf_log( 'info', 'Update score of "%s" from %s to %s',
-                    $row->[0], $node_score, $row->[1] );
+                if ( $row->[1] < -1 ) {
+                    ocf_log( 'info', 'Update score of "%s" from %s to %s because replication lag (%s) is higher than given maxlag (%s).',
+                        $row->[0], $node_score, $row->[1], $row->[4], $maxlag );
+                }
+                else {
+                    ocf_log( 'info', 'Update score of "%s" from %s to %s because of a change in the replication lag (%s).',
+                        $row->[0], $node_score, $row->[1], $row->[4] );
+                }
                 _set_master_score( $row->[1], $row->[0] );
             }
             else {
@@ -979,13 +986,13 @@ sub ocf_meta_data {
 
            <parameter name="maxlag" unique="0" required="0">
               <longdesc lang="en">
-                Maximum lag allowed on a standby before we set a negative master score on it. The calculation
+	        Maximum lag allowed on a standby before we set a negative master score on it. The calculation
                 is based on the difference between the current xlog location on the master and the write
                 location on the standby.
                 This parameter must be a valid positive number as described in PostgreSQL documentation.
                 See: https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS-NUMERIC
               </longdesc>
-              <shortdesc lang="en">Maximum lag before we mark a standby as inappropriate to promote</shortdesc>
+              <shortdesc lang="en">Maximum write lag before we mark a standby as inappropriate to promote</shortdesc>
               <content type="integer" default="$maxlag_default" />
             </parameter>
 


### PR DESCRIPTION
This PR aims to improve the documentation of the maxlag parameter and the info messages as discussed in issue #73.

Tested on Debian 8, two node setup.

The ouput is like this:
```
Feb 22 20:08:18 srv2 pgsqlms(pgsqld)[5383]: INFO: Ignoring unknown application_name/node "pg_basebackup"
Feb 22 20:08:33 srv2 pgsqlms(pgsqld)[5489]: WARNING: No secondary connected to the master
Feb 22 20:08:48 srv2 pgsqlms(pgsqld)[5554]: WARNING: No secondary connected to the master
Feb 22 20:09:03 srv2 pgsqlms(pgsqld)[5690]: INFO: Update score of "srv1" from -1000 to 1000 because of a change in the replication lag (0).
Feb 22 20:33:49 srv2 pgsqlms(pgsqld)[14563]: INFO: Update score of "srv1" from 1000 to -1000 because replication lag (4202496) is higher than given maxlag (100).
Feb 22 20:34:53 srv2 pgsqlms(pgsqld)[14933]: INFO: Update score of "srv1" from -1000 to 1000 because of a change in the replication lag (0).
Feb 22 20:35:09 srv2 pgsqlms(pgsqld)[15020]: INFO: Update score of "srv1" from 1000 to -1000 because replication lag (1052336) is higher than given maxlag (100).
Feb 22 20:35:41 srv2 pgsqlms(pgsqld)[15212]: INFO: Update score of "srv1" from -1000 to 1000 because of a change in the replication lag (0).
```

After the switchover:
```
Feb 22 20:05:29 srv1 pgsqlms(pgsqld)[3925]: INFO: Current node TL#LSN: 7#6627000320
Feb 22 20:06:50 srv1 pgsqlms(pgsqld)[4128]: INFO: Instance "pgsqld" stopped
Feb 22 20:06:58 srv1 pgsqlms(pgsqld)[4316]: ERROR: Instance "pgsqld" failed to start (rc: 1)
Feb 22 20:06:58 srv1 pgsqlms(pgsqld)[4375]: INFO: Instance "pgsqld" already stopped
Feb 22 20:08:56 srv1 pgsqlms(pgsqld)[4623]: INFO: Instance "pgsqld" started
Feb 22 22:45:24 srv1 pgsqlms(pgsqld)[14262]: INFO: Promoting instance on node "srv1"
Feb 22 22:45:25 srv1 pgsqlms(pgsqld)[14262]: INFO: Current node TL#LSN: 9#12086671736
Feb 22 22:45:25 srv1 pgsqlms(pgsqld)[14308]: INFO: Waiting for the promote to complete
Feb 22 22:45:26 srv1 pgsqlms(pgsqld)[14308]: INFO: Promote complete
Feb 22 22:45:26 srv1 pgsqlms(pgsqld)[14376]: WARNING: No secondary connected to the master
Feb 22 22:45:26 srv1 pgsqlms(pgsqld)[14376]: WARNING: "srv2" is not connected to the primary
...
Feb 22 22:49:30 srv1 pgsqlms(pgsqld)[16051]: WARNING: No secondary connected to the master
Feb 22 22:49:30 srv1 pgsqlms(pgsqld)[16051]: WARNING: "srv2" is not connected to the primary
Feb 22 22:49:45 srv1 pgsqlms(pgsqld)[16156]: INFO: Update score of "srv2" from -1000 to 1000 because of a change in the replication lag (0).
Feb 22 22:52:33 srv1 pgsqlms(pgsqld)[17201]: INFO: Update score of "srv2" from 1000 to -1000 because replication lag (8388608) is higher than given maxlag (100).
Feb 22 22:53:53 srv1 pgsqlms(pgsqld)[17679]: INFO: Update score of "srv2" from -1000 to 1000 because of a change in the replication lag (0).
Feb 22 22:54:25 srv1 pgsqlms(pgsqld)[17869]: INFO: Update score of "srv2" from 1000 to -1000 because replication lag (6479976) is higher than given maxlag (100).
Feb 22 22:54:42 srv1 pgsqlms(pgsqld)[17951]: INFO: Update score of "srv2" from -1000 to 1000 because of a change in the replication lag (0).
Feb 22 22:54:58 srv1 pgsqlms(pgsqld)[18072]: INFO: Update score of "srv2" from 1000 to -1000 because replication lag (33554432) is higher than given maxlag (100).
Feb 22 22:57:26 srv1 pgsqlms(pgsqld)[18913]: INFO: Update score of "srv2" from -1000 to 1000 because of a change in the replication lag (0).
```