### PR TITLE
Add 'kind=Mandatory' to the order constraints

### DIFF
--- a/Quick_Start-CentOS-6.md
+++ b/Quick_Start-CentOS-6.md
@@ -354,8 +354,8 @@ process.
 
 ```
 pcs -f cluster1.xml constraint colocation add pgsql-master-ip with master pgsql-ha INFINITY
-pcs -f cluster1.xml constraint order promote pgsql-ha then start pgsql-master-ip symmetrical=false
-pcs -f cluster1.xml constraint order demote pgsql-ha then stop pgsql-master-ip symmetrical=false
+pcs -f cluster1.xml constraint order promote pgsql-ha then start pgsql-master-ip symmetrical=false kind=Mandatory
+pcs -f cluster1.xml constraint order demote pgsql-ha then stop pgsql-master-ip symmetrical=false kind=Mandatory
 ```
 
 And finally, we define a preference for our master node:

--- a/Quick_Start-CentOS-7.md
+++ b/Quick_Start-CentOS-7.md
@@ -346,8 +346,8 @@ We now define the collocation between `pgsql-ha` and `pgsql-master-ip`.
 
 ```
 pcs -f cluster1.xml constraint colocation add pgsql-master-ip with master pgsql-ha INFINITY
-pcs -f cluster1.xml constraint order promote pgsql-ha then start pgsql-master-ip symmetrical=false
-pcs -f cluster1.xml constraint order demote pgsql-ha then stop pgsql-master-ip symmetrical=false
+pcs -f cluster1.xml constraint order promote pgsql-ha then start pgsql-master-ip symmetrical=false kind=Mandatory
+pcs -f cluster1.xml constraint order demote pgsql-ha then stop pgsql-master-ip symmetrical=false kind=Mandatory
 ```
 
 We can now push our CIB to the cluster, which will start all the magic stuff:


### PR DESCRIPTION
This is supposed to avoid that the depending resource stay around when
the first action is not finished and true.